### PR TITLE
bugfix: do not use HTTPS proxy for contacting SPP by default

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -33,6 +33,10 @@
 # Useful for stopping users from connecting from a local network.
 ; exclude_networks=10.0.0.0/8, 192.168.0.0/16
 
+# To use the system https proxy, set 'use_https_proxy=yes'
+# Otherwise it is assumed that SPP can be reached directly.
+use_https_proxy=no
+
 [credential_store]
 # Name of the local credential store configured in SPS for hosting sensitive
 # configuration data. For more information, read the "Store sensitive

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -56,6 +56,12 @@ class Plugin(AAPlugin):
         (username, domain) = split_username(self.username)
         return domain if domain else 'Local'
 
+    def set_https_proxy(self):
+        if self.plugin_configuration.getboolean('plugin', 'use_https_proxy', False):
+            super().set_https_proxy()
+        else:
+            self.logger.info("HTTPS proxy server configuration ignored, communicating directly")
+
     def do_authenticate(self):
         self.session_cookie.setdefault("SessionId", self.connection.session_id)
 


### PR DESCRIPTION
Usually SPP is directly connected. Starling would be reached usually via
HTTPS proxy. The two settings are exclusive so give an option to turn
off HTTPS proxy usage in the plugin and make it the default.

Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>