### PR TITLE
Fix version error

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,4 +6,3 @@ api: 1.8.2
 entry_point: main.py
 author_name: One Identity Safeguard Remote Access
 author_email: QDL.QBU-OI.RD.Safeguard.Integration@oneidentity.com
-scb_max_version: 13.0.0~


### PR DESCRIPTION
Due to Python’s string sorting behavior, a version number like "10" will be ordered before "9". As a result, the SPS may treat a plugin with version "10" in the MANIFEST file as older than one with version "9".